### PR TITLE
feat: 启动时若没有Core组件强制跳转配置界面

### DIFF
--- a/packages/renderer/src/components/Setting/Version/Index.vue
+++ b/packages/renderer/src/components/Setting/Version/Index.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { onMounted, computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import useSettingStore from '@/store/settings'
 import {
   NSpace,
@@ -40,8 +41,15 @@ function showDownloadModal () {
   show.value = true
 }
 
+const route = useRoute()
+
 onMounted(async () => {
-  settingStore.updateVersionInfo()
+  if (route.query.requireInstallComponent) {
+    // 已经在Device页面做过更新
+    show.value = true
+  } else {
+    settingStore.updateVersionInfo()
+  }
 })
 </script>
 

--- a/packages/renderer/src/layouts/pages/Device.vue
+++ b/packages/renderer/src/layouts/pages/Device.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { NInput, NAlert, NButton, NIcon, NText, NForm, NFormItem } from 'naive-ui'
+import { useRouter } from 'vue-router'
 import useDeviceStore from '@/store/devices'
+import useSettingStore from '@/store/settings'
 // import { uuidV4 } from "@common/uuid";
 import IconLink from '@/assets/icons/link.svg?component'
 import _ from 'lodash'
@@ -10,7 +12,7 @@ import { showMessage } from '@/utils/message'
 const address = ref('')
 const deviceStore = useDeviceStore()
 
-function addressChecker (cs: string) {
+function addressChecker(cs: string) {
   let [ip, port] = cs.split(':')
   if (!port) {
     // adb默认端口
@@ -60,6 +62,22 @@ async function handleCustomConnect () {
     showMessage('设备地址不对哦，检查一下吧', { type: 'error', duration: 5000 })
   }
 }
+
+const router = useRouter()
+const settingStore = useSettingStore()
+
+onMounted(async () => {
+  // 检查是否没有正确安装组件
+  await settingStore.updateVersionInfo()
+  if (!settingStore.version.core.current) {
+    router.push({
+      path: '/settings',
+      query: {
+        requireInstallComponent: 1
+      }
+    })
+  }
+})
 </script>
 
 <template>

--- a/packages/renderer/src/store/settings.ts
+++ b/packages/renderer/src/store/settings.ts
@@ -31,7 +31,7 @@ export interface SettingAction {
   setPenguinReportId: (reportId: string) => void
   setYituliuReportId: (reportId: string) => void
   changeLocale: (locale: Locale) => void
-  updateVersionInfo: () => void
+  updateVersionInfo: () => Promise<void>
   toggleMonsters: () => void
   setTouchMode: (mode: TouchMode) => void
 }


### PR DESCRIPTION
解决 #133

> 说起来, 建议配置一个代码格式化工具, 或者在vscode设置里面加一个禁止自动格式化, 不然开了格式化的人编辑特别容易造成大量无效修改